### PR TITLE
Add basic support for `textDcoument/hover` request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,14 +81,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "efmt_core"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da409a17c1a6ea6b4e448d9709f02c715bf08d068e14299a7dfca655e58e0d19"
+checksum = "150737d0d1eae8563af99ecfc6ffa6b3838ed0e0b604f6927369d98f672c6f9f"
 dependencies = [
  "efmt_derive",
  "erl_tokenize",
@@ -240,7 +240,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -394,7 +394,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -426,21 +426,21 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 dependencies = [
  "serde",
 ]
@@ -515,18 +515,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -562,35 +562,35 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -649,7 +649,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "url"
@@ -803,28 +803,28 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -847,5 +847,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Supported LSP features
 - [x] [textDocument/semanticTokens/range](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens)
 - [ ] [textDocument/documentHighlight](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight)
   - [ ] Variable
+- [x] [textDocument/hover](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover)
+  - NOTE: Only the `-doc` and `-moduledoc` attributes are supported (i.e., doc comments are not supported)
 
 Editor integrations
 -------------------
 
-ErlLS can be used with any [LSP](https://microsoft.github.io/language-server-protocol/) clients. 
+ErlLS can be used with any [LSP](https://microsoft.github.io/language-server-protocol/) clients.
 Here are a few examples.
 
 ### Visual Studio Code / Visual Studio Code for the Web

--- a/erlls_core/src/hover_provider.rs
+++ b/erlls_core/src/hover_provider.rs
@@ -78,6 +78,9 @@ impl HoverProvider {
             let text = documents.get_or_read_text(&target_uri).await.or_fail()?;
             let tree = SyntaxTree::parse_as_much_as_possible(text).or_fail()?;
             if let Some(doc) = tree.find_hover_doc(target) {
+                if doc.is_empty() {
+                    break;
+                }
                 return Ok(doc);
             } else {
                 visited.insert(target_uri.clone());

--- a/erlls_core/src/hover_provider.rs
+++ b/erlls_core/src/hover_provider.rs
@@ -1,0 +1,21 @@
+use orfail::OrFail;
+
+use crate::{
+    document::DocumentRepository,
+    error::ResponseError,
+    fs::FileSystem,
+    message::{HoverParams, ResponseMessage},
+};
+
+#[derive(Debug)]
+pub struct HoverProvider;
+
+impl HoverProvider {
+    pub fn handle_request<FS: FileSystem>(
+        &mut self,
+        params: HoverParams,
+        documents: &DocumentRepository<FS>,
+    ) -> Result<ResponseMessage, ResponseError> {
+        todo!()
+    }
+}

--- a/erlls_core/src/hover_provider.rs
+++ b/erlls_core/src/hover_provider.rs
@@ -97,6 +97,6 @@ impl HoverProvider {
             }
         }
 
-        Err(orfail::Failure::new("No hover doc found"))
+        Err(orfail::Failure::new("No doc found"))
     }
 }

--- a/erlls_core/src/hover_provider.rs
+++ b/erlls_core/src/hover_provider.rs
@@ -4,7 +4,7 @@ use crate::{
     document::DocumentRepository,
     error::ResponseError,
     fs::FileSystem,
-    message::{HoverParams, ResponseMessage},
+    message::{Hover, HoverParams, MarkupContent, MarkupKind, ResponseMessage},
 };
 
 #[derive(Debug)]
@@ -13,9 +13,16 @@ pub struct HoverProvider;
 impl HoverProvider {
     pub fn handle_request<FS: FileSystem>(
         &mut self,
-        params: HoverParams,
-        documents: &DocumentRepository<FS>,
+        _params: HoverParams,
+        _documents: &DocumentRepository<FS>,
     ) -> Result<ResponseMessage, ResponseError> {
-        todo!()
+        let hover = Hover {
+            contents: MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "Hello, world!".to_string(),
+            },
+            range: None,
+        };
+        Ok(ResponseMessage::result(hover).or_fail()?)
     }
 }

--- a/erlls_core/src/hover_provider.rs
+++ b/erlls_core/src/hover_provider.rs
@@ -5,17 +5,49 @@ use crate::{
     error::ResponseError,
     fs::FileSystem,
     message::{Hover, HoverParams, MarkupContent, MarkupKind, ResponseMessage},
+    syntax_tree::{SyntaxTree, Target},
 };
 
 #[derive(Debug)]
 pub struct HoverProvider;
 
 impl HoverProvider {
-    pub fn handle_request<FS: FileSystem>(
+    pub async fn handle_request<FS: FileSystem>(
         &mut self,
-        _params: HoverParams,
-        _documents: &DocumentRepository<FS>,
+        params: HoverParams,
+        documents: &mut DocumentRepository<FS>,
     ) -> Result<ResponseMessage, ResponseError> {
+        let document = documents
+            .get_from_editings(&params.text_document().uri)
+            .or_fail()?;
+        let position = params.position();
+        let efmt_position = document.text.to_efmt_position(position);
+        let mut tree = SyntaxTree::parse(document.text.to_string())
+            .or_else(|err| {
+                SyntaxTree::partial_parse(document.text.to_string(), efmt_position).map_err(|_| err)
+            })
+            .or_fail()?;
+        let Some(target) = tree.find_target(efmt_position) else {
+            return Err(ResponseError::request_failed().message("No definitions found"));
+        };
+        log::debug!("target: {target:?}");
+
+        let mut target_uri = params.text_document().uri.clone();
+        match &target {
+            Target::Module { module_name, .. }
+            | Target::Function {
+                module_name: Some(module_name),
+                ..
+            }
+            | Target::Type {
+                module_name: Some(module_name),
+                ..
+            } => {
+                target_uri = documents.resolve_module_uri(module_name).await.or_fail()?;
+            }
+            _ => {}
+        }
+
         let hover = Hover {
             contents: MarkupContent {
                 kind: MarkupKind::Markdown,

--- a/erlls_core/src/lib.rs
+++ b/erlls_core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod formatting_provider;
 pub mod fs;
 pub mod header;
+pub mod hover_provider;
 pub mod message;
 pub mod push_diagnostics_provider;
 pub mod semantic_tokens_provider;

--- a/erlls_core/src/message.rs
+++ b/erlls_core/src/message.rs
@@ -596,6 +596,13 @@ pub struct PublishDiagnosticsParams {
     pub version: Option<i32>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HoverParams {
+    #[serde(flatten)]
+    pub text_document_position: TextDocumentPositionParams,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SemanticTokenType {

--- a/erlls_core/src/message.rs
+++ b/erlls_core/src/message.rs
@@ -237,6 +237,7 @@ impl Default for ServerInfo {
 pub struct ServerCapabilities {
     pub document_formatting_provider: bool,
     pub definition_provider: bool,
+    pub hover_provider: bool,
     pub completion_provider: CompletionOptions,
     pub semantic_tokens_provider: serde_json::Value,
     pub text_document_sync: TextDocumentSyncKind,
@@ -248,6 +249,7 @@ impl Default for ServerCapabilities {
         Self {
             document_formatting_provider: true,
             definition_provider: true,
+            hover_provider: true,
             completion_provider: CompletionOptions::default(),
             semantic_tokens_provider: SemanticTokensProvider::options(),
             text_document_sync: TextDocumentSyncKind::INCREMENTAL,

--- a/erlls_core/src/message.rs
+++ b/erlls_core/src/message.rs
@@ -603,6 +603,16 @@ pub struct HoverParams {
     pub text_document_position: TextDocumentPositionParams,
 }
 
+impl HoverParams {
+    pub fn text_document(&self) -> &TextDocumentIdentifier {
+        &self.text_document_position.text_document
+    }
+
+    pub fn position(&self) -> Position {
+        self.text_document_position.position
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hover {

--- a/erlls_core/src/message.rs
+++ b/erlls_core/src/message.rs
@@ -603,6 +603,27 @@ pub struct HoverParams {
     pub text_document_position: TextDocumentPositionParams,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Hover {
+    pub contents: MarkupContent,
+    pub range: Option<Range>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkupContent {
+    pub kind: MarkupKind,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MarkupKind {
+    PlainText,
+    Markdown,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SemanticTokenType {

--- a/erlls_core/src/server.rs
+++ b/erlls_core/src/server.rs
@@ -131,10 +131,14 @@ impl<FS: FileSystem> LanguageServer<FS> {
                             .handle_full_request(params, &self.document_repository)
                     })
                 }
-                "textDocument/hover" => deserialize_params(msg.params).and_then(|params| {
-                    self.hover_provider
-                        .handle_request(params, &self.document_repository)
-                }),
+                "textDocument/hover" => match deserialize_params(msg.params) {
+                    Err(e) => Err(e),
+                    Ok(params) => {
+                        self.hover_provider
+                            .handle_request(params, &mut self.document_repository)
+                            .await
+                    }
+                },
                 "shutdown" => Ok(ResponseMessage::default()),
                 _ => {
                     todo!("handle_request: method={}", msg.method)

--- a/erlls_core/src/server.rs
+++ b/erlls_core/src/server.rs
@@ -6,6 +6,7 @@ use crate::{
     error::ResponseError,
     formatting_provider::FormattingProvider,
     fs::FileSystem,
+    hover_provider::HoverProvider,
     message::{
         InitializeParams, InitializeResult, Message, NotificationMessage, RequestMessage,
         ResponseMessage,
@@ -25,6 +26,7 @@ pub struct LanguageServer<FS> {
     definition_provider: DefinitionProvider,
     formatting_provider: FormattingProvider,
     completion_provider: CompletionProvider,
+    hover_provider: HoverProvider,
     semantic_tokens_provider: SemanticTokensProvider,
     push_diagnostics_provider: PushDiagnosticsProvider,
 }
@@ -39,6 +41,7 @@ impl<FS: FileSystem> LanguageServer<FS> {
             definition_provider: DefinitionProvider,
             formatting_provider: FormattingProvider,
             completion_provider: CompletionProvider,
+            hover_provider: HoverProvider,
             semantic_tokens_provider: SemanticTokensProvider,
             push_diagnostics_provider: PushDiagnosticsProvider,
         }
@@ -128,6 +131,10 @@ impl<FS: FileSystem> LanguageServer<FS> {
                             .handle_full_request(params, &self.document_repository)
                     })
                 }
+                "textDocument/hover" => deserialize_params(msg.params).and_then(|params| {
+                    self.hover_provider
+                        .handle_request(params, &self.document_repository)
+                }),
                 "shutdown" => Ok(ResponseMessage::default()),
                 _ => {
                     todo!("handle_request: method={}", msg.method)

--- a/erlls_core/src/syntax_tree.rs
+++ b/erlls_core/src/syntax_tree.rs
@@ -202,6 +202,18 @@ impl SyntaxTree {
             })
     }
 
+    pub fn find_hover_doc(&self, target: &Target) -> Option<String> {
+        let text = self.ts.text();
+        self.module
+            .as_ref()
+            .and_then(|x| x.find_hover_doc(&text, target))
+            .or_else(|| {
+                self.maybe_partial_module
+                    .as_ref()
+                    .and_then(|x| x.find_hover_doc(&text, target))
+            })
+    }
+
     pub fn find_target(&mut self, position: Position) -> Option<Target> {
         let mut candidate = None;
         for macro_call in self.ts.macros().values() {
@@ -283,6 +295,10 @@ pub trait FindTarget {
     }
 }
 
+pub trait FindHoverDoc {
+    fn find_hover_doc(&self, text: &str, target: &Target) -> Option<String>;
+}
+
 impl<const ALLOW_PARTIAL_FAILURE: bool> FindTarget
     for efmt_core::items::Module<ALLOW_PARTIAL_FAILURE>
 {
@@ -293,6 +309,14 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> FindTarget
             }
         }
         None
+    }
+}
+
+impl<const ALLOW_PARTIAL_FAILURE: bool> FindHoverDoc
+    for efmt_core::items::Module<ALLOW_PARTIAL_FAILURE>
+{
+    fn find_hover_doc(&self, text: &str, target: &Target) -> Option<String> {
+        todo!()
     }
 }
 

--- a/erlls_core/src/syntax_tree.rs
+++ b/erlls_core/src/syntax_tree.rs
@@ -320,13 +320,10 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> FindHoverDoc
             let Some(module_name) = target.module_name() else {
                 return Some(());
             };
-            match form.get() {
-                efmt_core::items::forms::Form::Module(module_attr) => {
-                    if module_attr.module_name().value() != module_name {
-                        return None;
-                    }
+            if let efmt_core::items::forms::Form::Module(f) = form.get() {
+                if f.module_name().value() != module_name {
+                    return None;
                 }
-                _ => {}
             }
             Some(())
         };
@@ -336,26 +333,23 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> FindHoverDoc
                 let mut doc = String::new();
                 for form in self.children() {
                     check_module(form)?;
-                    match form.get() {
-                        efmt_core::items::forms::Form::Attr(attr) => {
-                            if !(attr.name() == "moduledoc" && attr.values().len() == 1) {
-                                continue;
-                            }
-                            if !doc.is_empty() {
-                                doc.push_str("\n-n---\n\n");
-                            }
-                            if let Some(s) = attr.values()[0].as_string() {
-                                doc.push_str(s);
-                            } else {
-                                doc.push_str(&format!("```erlang\n{}\n```", attr.text(text)));
-                            }
+                    if let efmt_core::items::forms::Form::Attr(attr) = form.get() {
+                        if !(attr.name() == "moduledoc" && attr.values().len() == 1) {
+                            continue;
                         }
-                        _ => {}
+                        if !doc.is_empty() {
+                            doc.push_str("\n-n---\n\n");
+                        }
+                        if let Some(s) = attr.values()[0].as_string() {
+                            doc.push_str(s);
+                        } else {
+                            doc.push_str(&format!("```erlang\n{}\n```", attr.text(text)));
+                        }
                     }
                 }
                 Some(doc)
             }
-            Target::Include { .. } | Target::Variable { .. } => return Some("".to_owned()),
+            Target::Include { .. } | Target::Variable { .. } => Some("".to_owned()),
             Target::Type { .. }
             | Target::Function { .. }
             | Target::Macro { .. }

--- a/erlls_core/src/syntax_tree.rs
+++ b/erlls_core/src/syntax_tree.rs
@@ -340,7 +340,7 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> FindHoverDoc
                         efmt_core::items::forms::Form::Attr(attr)=>{
                             if !(attr.name() == "moduledoc" && attr.values().len() == 1) {
                                 continue;
-                            }
+                             }
                             if let Some(s) = attr.values()[0].as_string() {
                                 doc.push_str("\n\n");
                                 doc.push_str(s);


### PR DESCRIPTION
Related issue: https://github.com/sile/erlls/issues/3

Copilot Summary
-------------

This pull request introduces the implementation of the hover feature in the language server. The changes include adding support for hover requests, updating the server capabilities, and implementing the necessary logic to handle hover requests and provide hover documentation.

Key changes:

### Hover Feature Implementation:
* Added a new `hover_provider` module and implemented the `HoverProvider` struct with methods to handle hover requests and find hover documentation. (`erlls_core/src/hover_provider.rs`)
* Updated `ServerCapabilities` to include the `hover_provider` field and set its default value to `true`. (`erlls_core/src/message.rs`) [[1]](diffhunk://#diff-f6dcd90e0645aa86a6e616ba33506ef4efbc0aadca9321e26c8803d1869c2725R240) [[2]](diffhunk://#diff-f6dcd90e0645aa86a6e616ba33506ef4efbc0aadca9321e26c8803d1869c2725R252)
* Added `HoverParams`, `Hover`, `MarkupContent`, and `MarkupKind` structs to handle hover request parameters and responses. (`erlls_core/src/message.rs`)

### Integration with Language Server:
* Integrated the `HoverProvider` into the `LanguageServer` struct and initialized it in the server. (`erlls_core/src/server.rs`) [[1]](diffhunk://#diff-c991fdf2f86ee7846a1478eaa9accea7af64237a25fda46c8a120a7f16155682R9) [[2]](diffhunk://#diff-c991fdf2f86ee7846a1478eaa9accea7af64237a25fda46c8a120a7f16155682R29) [[3]](diffhunk://#diff-c991fdf2f86ee7846a1478eaa9accea7af64237a25fda46c8a120a7f16155682R44)
* Added handling for the `textDocument/hover` request in the language server's request dispatcher. (`erlls_core/src/server.rs`)

### Syntax Tree Enhancements:
* Added methods to the `SyntaxTree` struct to find hover documentation for various targets. (`erlls_core/src/syntax_tree.rs`) [[1]](diffhunk://#diff-8ae3385ea835ff2d542fc3f58e03c3d5faf042722f41a68cc20d486bbdf9de98R205-R216) [[2]](diffhunk://#diff-8ae3385ea835ff2d542fc3f58e03c3d5faf042722f41a68cc20d486bbdf9de98R298-R301) [[3]](diffhunk://#diff-8ae3385ea835ff2d542fc3f58e03c3d5faf042722f41a68cc20d486bbdf9de98R315-R476) [[4]](diffhunk://#diff-8ae3385ea835ff2d542fc3f58e03c3d5faf042722f41a68cc20d486bbdf9de98R1347-R1372)
* Implemented the `FindHoverDoc` trait to support hover documentation lookup within the syntax tree. (`erlls_core/src/syntax_tree.rs`)

### Documentation Update:
* Updated the `README.md` to mark the `textDocument/hover` feature as supported, with a note on the supported attributes. (`README.md`)